### PR TITLE
Improvements to JMS Throttling implementation

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConstants.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConstants.java
@@ -422,11 +422,13 @@ public class JMSConstants {
     public static final String JMS_PROXY_THROTTLE_ENABLED = "jms.proxy.throttle.enabled";
     /** Throttling mode specified */
     public static final String JMS_PROXY_THROTTLE_MODE = "jms.proxy.throttle.mode";
-    /** Throttling limit of messages per minute */
-    public static final String JMS_PROXY_THROTTLE_PER_MIN = "jms.proxy.throttle.limitPerMinute";
+    /** Throttling limit of messages */
+    public static final String JMS_PROXY_THROTTLE_MESSAGE_LIMIT = "jms.proxy.throttle.messageLimit";
+    /** Throttling duration */
+    public static final String JMS_PROXY_THROTTLE_DURATION = "jms.proxy.throttle.duration";
     /** Batch Throttling constant */
     public static final String JMS_PROXY_BATCH_THROTTLE = "batch";
-    /** Fixed Interval Throttlinh constant */
+    /** Fixed Interval Throttling constant */
     public static final String JMS_PROXY_FIXED_INTERVAL_THROTTLE = "fixed-interval";
 
 }

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/ServiceTaskManagerFactory.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/ServiceTaskManagerFactory.java
@@ -132,9 +132,13 @@ public class ServiceTaskManagerFactory {
             stm.setReconnectionProgressionFactor(dValue);
         }
 
-        value = getOptionalIntProperty(JMSConstants.JMS_PROXY_THROTTLE_PER_MIN, svc, cf);
+        value = getOptionalIntProperty(JMSConstants.JMS_PROXY_THROTTLE_MESSAGE_LIMIT, svc, cf);
         if (value != null) {
-            stm.setThrottleLimitPerMin(value);
+            stm.setThrottleMessageLimit(value);
+        }
+        Long lvalue = getOptionalLongProperty(JMSConstants.JMS_PROXY_THROTTLE_DURATION, svc, cf);
+        if (lvalue != null) {
+            stm.setThrottleDuration(lvalue);
         }
         Boolean bValue = getOptionalBooleanProperty(JMSConstants.JMS_PROXY_THROTTLE_ENABLED, svc, cf);
         if (bValue != null) {


### PR DESCRIPTION
- JMS_PROXY_THROTTLE_PER_MIN to JMS_PROXY_THROTTLE_MESSAGES_LIMIT
- Added JMS_PROXY_THROTTLE_DURATION to manually set the duration when
defining the proxy. Must be set in mills. Default 60000 mills (one min)
- Added else statement to handle cases where consumptionDuration is
greater than the throttleDuration
